### PR TITLE
Fix maven build to run unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,21 +28,9 @@
 		<defaultGoal>process-resources</defaultGoal>
 		<plugins>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>templating-maven-plugin</artifactId>
-				<version>1.0-alpha-3</version>
-				<executions>
-					<execution>
-						<id>filter-tests</id>
-						<goals>
-							<goal>filter-test-sources</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>net.alchim31.maven</groupId>
 				<artifactId>yuicompressor-maven-plugin</artifactId>
+				<version>1.5.1</version>
 				<executions>
 					<execution>
 						<id>compress-js</id>
@@ -226,11 +214,9 @@
 						<configuration>
 							<executable>node_modules/jasmine-node/bin/jasmine-node</executable>
 							<arguments>
+								<argument>--verbose</argument>
 								<argument>--forceexit</argument>
 								<argument>target/test</argument>
-								<argument>--junitreport</argument>
-								<argument>--output</argument>
-								<argument>target/failsafe-reports/</argument>
 							</arguments>
 						</configuration>
 					</execution>

--- a/src/test/client-harness.js
+++ b/src/test/client-harness.js
@@ -63,11 +63,11 @@ function ensureValue(prop,value) {
 }
 
 module.exports = {
-    server: ensureValue("${test.server}","127.0.0.1"),
+    server: ensureValue("${test.server}","messagesight.demos.ibm.com"),
     port: parseInt(ensureValue("${test.server.port}","1883")),
     path: ensureValue("${test.server.path}","/mqtt"),
     mqttVersion: parseInt(ensureValue("${test.server.mqttVersion}","3")),
-    interopServer: ensureValue("${test.interopServer}","127.0.0.1"),
+    interopServer: ensureValue("${test.interopServer}","messagesight.demos.ibm.com"),
     interopPort: parseInt(ensureValue("${test.interopPort}","1883")),
     interopPath: ensureValue("${test.interopPath}","/mqtt")
 }


### PR DESCRIPTION
For Maven pom.xml: 
  - removed the duplicate  templating-maven-plugin
  - added version for yuicompressor-maven-plugin
  - removed the problem arguments that prevented unit tests to run

src/test/client-harnbess.js :
  - Set default test broker to messagesight.demos.ibm.com because local host won't work for most users

Note that I am still seeing 1 failed test, but it is better than before.