### PR TITLE
Fix typo on will-message connect

### DIFF
--- a/src/paho-mqtt.js
+++ b/src/paho-mqtt.js
@@ -280,7 +280,8 @@ function onMessageArrived(message) {
 			var remLength = 0;
 			var topicStrLength = [];
 			var destinationNameLength = 0;
-			var willMessagePayloadBytes;
+			var willMessagePayloadBytes; // used only for MESSAGE_TYPE.CONNECT
+			var payloadBytes; // used only for MESSAGE_TYPE.PUBLISH
 
 			// if the message contains a messageIdentifier then we need two bytes for that
 			if (this.messageIdentifier !== undefined)
@@ -304,7 +305,7 @@ function onMessageArrived(message) {
 					// Will message is always a string, sent as UTF-8 characters with a preceding length.
 					willMessagePayloadBytes = this.willMessage.payloadBytes;
 					if (!(willMessagePayloadBytes instanceof Uint8Array))
-						willMessagePayloadBytes = new Uint8Array(payloadBytes);
+						willMessagePayloadBytes = new Uint8Array(willMessagePayloadBytes);
 					remLength += willMessagePayloadBytes.byteLength +2;
 				}
 				if (this.userName !== undefined)
@@ -342,7 +343,7 @@ function onMessageArrived(message) {
 				if (this.payloadMessage.retained) first |= 0x01;
 				destinationNameLength = UTF8Length(this.payloadMessage.destinationName);
 				remLength += destinationNameLength + 2;
-				var payloadBytes = this.payloadMessage.payloadBytes;
+				payloadBytes = this.payloadMessage.payloadBytes;
 				remLength += payloadBytes.byteLength;
 				if (payloadBytes instanceof ArrayBuffer)
 					payloadBytes = new Uint8Array(payloadBytes);


### PR DESCRIPTION
I noticed something when using paho-mqtt.js in my application, due to linting.

`willMessagePayloadBytes` is used only in case the message type is "connect".
`payloadBytes` is used only when the message type is "publish".

There seems to be a clear typo in the code, as `payloadBytes` is used before being defined.
I added some comments to make others understand what each variable is used in.