### PR TITLE
Declare wireMessage var

### DIFF
--- a/src/paho-mqtt.js
+++ b/src/paho-mqtt.js
@@ -944,7 +944,7 @@ var PahoMQTT = (function (global) {
 	ClientImpl.prototype.send = function (message) {
 		this._trace("Client.send", message);
 
-		wireMessage = new WireMessage(MESSAGE_TYPE.PUBLISH);
+		var wireMessage = new WireMessage(MESSAGE_TYPE.PUBLISH);
 		wireMessage.payloadMessage = message;
 
 		if (this.connected) {
@@ -994,7 +994,7 @@ var PahoMQTT = (function (global) {
 		if (!this.socket)
 			throw new Error(format(ERROR.INVALID_STATE, ["not connecting or connected"]));
 
-		wireMessage = new WireMessage(MESSAGE_TYPE.DISCONNECT);
+		var wireMessage = new WireMessage(MESSAGE_TYPE.DISCONNECT);
 
 		// Run the disconnected call back as soon as the message has been sent,
 		// in case of a failure later on in the disconnect processing.


### PR DESCRIPTION
The `wireMessage` variable is not explicitly declared in certain places, causing runtime errors.

Should resolve https://github.com/eclipse/paho.mqtt.javascript/issues/168