### PR TITLE
Handle cases where localStorage access is denied

### DIFF
--- a/src/paho-mqtt.js
+++ b/src/paho-mqtt.js
@@ -106,7 +106,7 @@ function onMessageArrived(message) {
 	/**
 	 * @private
 	 */
-	var localStorage = global.localStorage || (function () {
+	var localStorage = (function () {
 		var data = {};
 
 		return {
@@ -115,6 +115,14 @@ function onMessageArrived(message) {
 			removeItem: function (key) { delete data[key]; },
 		};
 	})();
+	try {
+		if (global.localStorage) {
+			localStorage = global.localStorage;
+		}
+	} catch (err) {
+		// in browsers localStorage access can be disabled / blocked and even
+		// reading the localStorage property will result in an Access denied error
+	}
 
 		/**
 	 * Unique message type identifiers, with associated


### PR DESCRIPTION
In browsers when localStorage access is disabled for your domain the
browsers will throw an Access denied error if you try to even read the
localStorage property. This commit adds try/catch logic to handle the
error and use the in-memory fallback.

Signed-off-by: Matt Cowan <mcowan@atlassian.com>
