### PR TITLE
No implicit global WebSocket

### DIFF
--- a/src/paho-mqtt.js
+++ b/src/paho-mqtt.js
@@ -1049,9 +1049,9 @@ function onMessageArrived(message) {
 
 
 			if (this.connectOptions.mqttVersion < 4) {
-				this.socket = new WebSocket(wsurl, ["mqttv3.1"]);
+				this.socket = new global.WebSocket(wsurl, ["mqttv3.1"]);
 			} else {
-				this.socket = new WebSocket(wsurl, ["mqtt"]);
+				this.socket = new global.WebSocket(wsurl, ["mqtt"]);
 			}
 			this.socket.binaryType = "arraybuffer";
 			this.socket.onopen = scope(this._on_socket_open, this);

--- a/src/test/client-harness.js
+++ b/src/test/client-harness.js
@@ -65,7 +65,7 @@ global.Paho = Paho
 
 
 function ensureValue(prop, value) {
-  if (prop === '' || prop[0] === '$') {
+  if (prop === undefined || prop === '' || prop[0] === '$') {
     return value
   }
   return prop


### PR DESCRIPTION
Hi there - I'm using Paho to connect to MQTT via websocket in an environment which is a modified version of Node.js.

It was causing an error "ReferenceError: WebSocket is not defined" due to the line https://github.com/eclipse/paho.mqtt.javascript/blob/develop/src/paho-mqtt.js#L1054, which contains
```javascript
  new WebSocket(...)
```

Changing this to
```javascript
  new global.WebSocket(...)
```

fixes the problem.