### PR TITLE
Error Stack fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+  - "8"
 before_install:
   - ./start-broker.sh
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-  - "8"
+node_js: 8
 before_install:
   - ./start-broker.sh
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
-node_js: 5
 before_install:
   - ./start-broker.sh
 script:

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+
+Thank you for your interest in this project managed by the Eclipse Foundation.
+
+The guidelines for contributions can be found in the CONTRIBUTING.md file.
+
+At a minimum, you must sign the Eclipse ECA, and sign off each commit.  
+
+To complete and submit a ECA, log into the Eclipse projects forge 
+You will need to create an account with the Eclipse Foundation if you have not already done so.
+Be sure to use the same email address when you register for the account that you intend to use when you commit to Git.
+Go to https://accounts.eclipse.org/user/eca to sign the Eclipse ECA.
+
+

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
 	"license": "EPL-1.0",
 	"devDependencies": {
 		"dotenv": "^4.0.0",
-		"eslint": "^4.12.1",
-		"jasmine-node": "1.14.x",
-		"jsdoc": "^3.5.5",
+		"eslint": "^4.19.1",
+		"jasmine-node": "^3.0.0",
+		"jsdoc": "^3.6.2",
 		"node-localstorage": "1.3.x",
 		"websocket": "1.x.x"
 	}

--- a/src/paho-mqtt.js
+++ b/src/paho-mqtt.js
@@ -1817,7 +1817,7 @@ function onMessageArrived(message) {
 					"onConnected":{
 						get: function() { return client.onConnected; },
 						set: function(newOnConnected) {
-							if (typeof newOnConnected === "function")
+							if (newOnConnected === null || typeof newOnConnected === "function")
 								client.onConnected = newOnConnected;
 							else
 								throw new Error(format(ERROR.INVALID_TYPE, [typeof newOnConnected, "onConnected"]));
@@ -1838,7 +1838,7 @@ function onMessageArrived(message) {
 					"onConnectionLost":{
 						get: function() { return client.onConnectionLost; },
 						set: function(newOnConnectionLost) {
-							if (typeof newOnConnectionLost === "function")
+							if (newOnConnectionLost === null || typeof newOnConnectionLost === "function")
 								client.onConnectionLost = newOnConnectionLost;
 							else
 								throw new Error(format(ERROR.INVALID_TYPE, [typeof newOnConnectionLost, "onConnectionLost"]));
@@ -1847,7 +1847,7 @@ function onMessageArrived(message) {
 					"onMessageDelivered":{
 						get: function() { return client.onMessageDelivered; },
 						set: function(newOnMessageDelivered) {
-							if (typeof newOnMessageDelivered === "function")
+							if (newOnMessageDelivered === null || typeof newOnMessageDelivered === "function")
 								client.onMessageDelivered = newOnMessageDelivered;
 							else
 								throw new Error(format(ERROR.INVALID_TYPE, [typeof newOnMessageDelivered, "onMessageDelivered"]));
@@ -1856,7 +1856,7 @@ function onMessageArrived(message) {
 					"onMessageArrived":{
 						get: function() { return client.onMessageArrived; },
 						set: function(newOnMessageArrived) {
-							if (typeof newOnMessageArrived === "function")
+							if (newOnMessageArrived === null || typeof newOnMessageArrived === "function")
 								client.onMessageArrived = newOnMessageArrived;
 							else
 								throw new Error(format(ERROR.INVALID_TYPE, [typeof newOnMessageArrived, "onMessageArrived"]));
@@ -1865,7 +1865,7 @@ function onMessageArrived(message) {
 					"trace":{
 						get: function() { return client.traceFunction; },
 						set: function(trace) {
-							if(typeof trace === "function"){
+							if(trace === null || typeof trace === "function"){
 								client.traceFunction = trace;
 							}else{
 								throw new Error(format(ERROR.INVALID_TYPE, [typeof trace, "onTrace"]));

--- a/src/paho-mqtt.js
+++ b/src/paho-mqtt.js
@@ -1260,7 +1260,7 @@ function onMessageArrived(message) {
 						this.receiveBuffer = byteArray.subarray(offset);
 					}
 				} catch (error) {
-					var errorStack = ((error.hasOwnProperty("stack") == "undefined") ? error.stack.toString() : "No Error Stack Available");
+					var errorStack = ((error.hasOwnProperty("stack") == "undefined") ? "No Error Stack Available" : error.stack.toString());
 					this._disconnected(ERROR.INTERNAL_ERROR.code , format(ERROR.INTERNAL_ERROR, [error.message,errorStack]));
 					return;
 				}
@@ -1449,7 +1449,7 @@ function onMessageArrived(message) {
 						this._disconnected(ERROR.INVALID_MQTT_MESSAGE_TYPE.code , format(ERROR.INVALID_MQTT_MESSAGE_TYPE, [wireMessage.type]));
 					}
 				} catch (error) {
-					var errorStack = ((error.hasOwnProperty("stack") == "undefined") ? error.stack.toString() : "No Error Stack Available");
+					var errorStack = ((error.hasOwnProperty("stack") == "undefined") ? "No Error Stack Available" : error.stack.toString());
 					this._disconnected(ERROR.INTERNAL_ERROR.code , format(ERROR.INTERNAL_ERROR, [error.message,errorStack]));
 					return;
 				}


### PR DESCRIPTION
When testing for stack on errors, the statements were reversed.
For instance, if user code throws an exception, it states "No Error Stack Available" on the error making it quite difficult to debug.
Furthermore, if client browser's Errors would not have the stack field, the fixed statements would throw an exception.

