### PR TITLE
Corrected inline examples in comments.

### DIFF
--- a/src/paho-mqtt.js
+++ b/src/paho-mqtt.js
@@ -55,7 +55,7 @@
  * Example:
  *
  * <code><pre>
-var client = new Paho.MQTT.Client(location.hostname, Number(location.port), "clientId");
+var client = new Paho.Client(location.hostname, Number(location.port), "clientId");
 client.onConnectionLost = onConnectionLost;
 client.onMessageArrived = onMessageArrived;
 client.connect({onSuccess:onConnect});
@@ -64,7 +64,7 @@ function onConnect() {
   // Once a connection has been made, make a subscription and send a message.
   console.log("onConnect");
   client.subscribe("/World");
-  var message = new Paho.MQTT.Message("Hello");
+  var message = new Paho.Message("Hello");
   message.destinationName = "/World";
   client.send(message);
 };


### PR DESCRIPTION
See: https://github.com/eclipse/paho.mqtt.javascript/issues/101

The example code at the top of the JS library causes an error. This is due to the package name containing 'MQTT' - where the code doesn't use this.


Thank you for your interest in this project managed by the Eclipse Foundation.

The guidelines for contributions can be found in the CONTRIBUTING.md file.

At a minimum, you must sign the Eclipse ECA, and sign off each commit.  

To complete and submit a ECA, log into the Eclipse projects forge 
You will need to create an account with the Eclipse Foundation if you have not already done so.
Be sure to use the same email address when you register for the account that you intend to use when you commit to Git.
Go to https://accounts.eclipse.org/user/eca to sign the Eclipse ECA.


