### PR TITLE
fix: correct handling of stack trace messages

### DIFF
--- a/src/paho-mqtt.js
+++ b/src/paho-mqtt.js
@@ -1260,7 +1260,7 @@ function onMessageArrived(message) {
 						this.receiveBuffer = byteArray.subarray(offset);
 					}
 				} catch (error) {
-					var errorStack = ((error.hasOwnProperty("stack") == "undefined") ? error.stack.toString() : "No Error Stack Available");
+					var errorStack = ((error.hasOwnProperty("stack") != "undefined") ? error.stack.toString() : "No Error Stack Available");
 					this._disconnected(ERROR.INTERNAL_ERROR.code , format(ERROR.INTERNAL_ERROR, [error.message,errorStack]));
 					return;
 				}
@@ -1449,7 +1449,7 @@ function onMessageArrived(message) {
 						this._disconnected(ERROR.INVALID_MQTT_MESSAGE_TYPE.code , format(ERROR.INVALID_MQTT_MESSAGE_TYPE, [wireMessage.type]));
 					}
 				} catch (error) {
-					var errorStack = ((error.hasOwnProperty("stack") == "undefined") ? error.stack.toString() : "No Error Stack Available");
+					var errorStack = ((error.hasOwnProperty("stack") != "undefined") ? error.stack.toString() : "No Error Stack Available");
 					this._disconnected(ERROR.INTERNAL_ERROR.code , format(ERROR.INTERNAL_ERROR, [error.message,errorStack]));
 					return;
 				}


### PR DESCRIPTION
Stack traces are not being added to message errors due to incorrect logic when checking for a stack trace. This commit corrects the logic so that stack traces are included in errors.